### PR TITLE
portfolio: recruiter-ready polish — hero, sections, theme, header

### DIFF
--- a/css/impressive.css
+++ b/css/impressive.css
@@ -3252,3 +3252,1107 @@ body.dark-mode .project-tech span {
     height: 180px;
   }
 }
+
+/* =========================================
+   PRO POLISH — hero badges, photo frame,
+   footer, back-to-top
+========================================= */
+
+/* Availability badge */
+.availability-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(34, 197, 94, 0.10);
+  color: #16a34a;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  border: 1px solid rgba(34, 197, 94, 0.25);
+  margin-bottom: 18px;
+}
+.availability-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #22c55e;
+  box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.6);
+  animation: pulse-dot 1.8s infinite;
+}
+@keyframes pulse-dot {
+  0%   { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.55); }
+  70%  { box-shadow: 0 0 0 10px rgba(34, 197, 94, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+}
+body.dark-mode .availability-badge {
+  background: rgba(34, 197, 94, 0.12);
+  color: #4ade80;
+  border-color: rgba(34, 197, 94, 0.35);
+}
+
+/* Hero tagline (under animated text) */
+.hero-tagline {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #ff7d39;
+  letter-spacing: 0.2px;
+  margin-top: 4px;
+}
+body.dark-mode .hero-tagline { color: var(--theme-primary); filter: brightness(1.15); }
+
+/* Hero photo */
+.hero-photo-wrap {
+  position: relative;
+  width: 100%;
+  max-width: 420px;
+  aspect-ratio: 1 / 1;
+  margin: 0 auto;
+}
+.hero-photo-ring {
+  position: absolute;
+  inset: -14px;
+  border-radius: 50%;
+  background: conic-gradient(from 0deg, var(--theme-primary), var(--theme-secondary), #0ea5e9, #06b6d4, var(--theme-primary));
+  filter: blur(10px);
+  opacity: 0.55;
+  animation: spin-ring 14s linear infinite;
+  z-index: 0;
+}
+@keyframes spin-ring {
+  to { transform: rotate(360deg); }
+}
+.hero-photo-frame {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  overflow: hidden;
+  background: #fff;
+  border: 6px solid #fff;
+  box-shadow: 0 25px 60px rgba(0,0,0,0.18);
+  z-index: 1;
+}
+body.dark-mode .hero-photo-frame {
+  background: #1f2937;
+  border-color: #1f2937;
+  box-shadow: 0 25px 60px rgba(0,0,0,0.5);
+}
+.hero-photo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.hero-tech-badge {
+  position: absolute;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #fff;
+  color: var(--theme-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  box-shadow: 0 10px 25px rgba(0,0,0,0.12);
+  z-index: 2;
+  animation: float-badge 5s ease-in-out infinite;
+}
+body.dark-mode .hero-tech-badge {
+  background: #111827;
+  color: var(--theme-primary);
+  box-shadow: 0 10px 25px rgba(0,0,0,0.5);
+  filter: brightness(1.15);
+}
+.hero-tech-dotnet  { top:  5%;  left: -4%;  animation-delay: 0s; }
+.hero-tech-angular { top: 18%;  right: -6%; animation-delay: 0.6s; color: #dd0031; }
+.hero-tech-docker  { bottom: 18%; right: -2%; animation-delay: 1.2s; color: #2496ed; }
+.hero-tech-redis   { bottom: 4%;  left: 8%;  animation-delay: 1.8s; color: #dc382c; }
+.hero-tech-cloud   { top: 45%;  left: -8%;  animation-delay: 2.4s; color: #ff9900; }
+@keyframes float-badge {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-10px); }
+}
+@media (max-width: 991px) {
+  .hero-photo-wrap { max-width: 320px; margin-top: 40px; }
+  .hero-tech-badge { width: 46px; height: 46px; font-size: 1.1rem; }
+}
+@media (max-width: 480px) {
+  .hero-photo-wrap { max-width: 260px; }
+  .hero-tech-badge { width: 40px; height: 40px; font-size: 1rem; }
+}
+
+/* Pro Footer */
+.footer-pro {
+  background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
+  color: #d1d5db;
+  position: relative;
+}
+.footer-pro::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--theme-primary), var(--theme-secondary), #0ea5e9, #06b6d4);
+}
+.footer-brand {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.footer-photo {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid var(--theme-primary);
+}
+.footer-name {
+  margin: 0;
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+}
+.footer-role {
+  color: #9ca3af;
+  font-size: 0.9rem;
+}
+.footer-cta {
+  color: #fff;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+.footer-email {
+  color: var(--theme-primary);
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.2s ease, filter 0.2s ease;
+  filter: brightness(1.25);
+}
+.footer-email:hover { filter: brightness(1.5); text-decoration: none; }
+.footer-social {
+  display: inline-flex;
+  gap: 10px;
+}
+.footer-social a {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  color: #d1d5db;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  text-decoration: none;
+}
+.footer-social a:hover {
+  background: var(--theme-primary);
+  color: #fff;
+  transform: translateY(-2px);
+}
+.footer-divider {
+  border-color: rgba(255, 255, 255, 0.08);
+  margin: 30px 0 20px;
+}
+.footer-copy {
+  color: #9ca3af;
+  font-size: 0.85rem;
+}
+
+/* Back-to-top */
+#back-to-top {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: none;
+  background: var(--theme-primary);
+  color: #fff;
+  font-size: 1.1rem;
+  box-shadow: 0 10px 25px rgba(var(--theme-rgb), 0.35);
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(10px);
+  transition: opacity 0.25s ease, transform 0.25s ease, visibility 0.25s ease, background 0.2s ease;
+  z-index: 999;
+}
+#back-to-top.visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+#back-to-top:hover { background: var(--theme-secondary); transform: translateY(-2px); }
+
+/* =========================================
+   RECRUITER-FACING ADDITIONS
+   Quick Facts · Case Study · GitHub Activity
+========================================= */
+
+/* ----- QUICK FACTS CARD ----- */
+.quick-facts-card {
+  margin-top: 28px;
+  margin-bottom: 24px;
+  background: #fff;
+  border-radius: 16px;
+  padding: 18px 20px;
+  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(0, 0, 0, 0.05);
+}
+/* Ensure the hero never clips: grow with content, give the bottom space below stats card */
+.about.full-screen {
+  padding-bottom: 5rem;
+}
+.stats-section { padding-top: 1.5rem !important; }
+body.dark-mode .quick-facts-card {
+  background: #1f2937;
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.45);
+}
+.quick-facts-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--theme-primary);
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px dashed rgba(0, 0, 0, 0.08);
+}
+body.dark-mode .quick-facts-header {
+  border-bottom-color: rgba(255, 255, 255, 0.1);
+}
+.quick-facts-header i { font-size: 1.05rem; }
+.quick-facts-hint {
+  margin-left: auto;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #9ca3af;
+  background: rgba(var(--theme-rgb), 0.08);
+  padding: 3px 8px;
+  border-radius: 999px;
+}
+.quick-facts-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.qf-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 12px;
+  font-size: 0.88rem;
+  padding: 5px 0;
+  border-bottom: 1px dotted rgba(0, 0, 0, 0.04);
+}
+.qf-row:last-child { border-bottom: none; }
+body.dark-mode .qf-row { border-bottom-color: rgba(255, 255, 255, 0.05); }
+.qf-key {
+  flex: 0 0 130px;
+  color: #6b7280;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+body.dark-mode .qf-key { color: #9ca3af; }
+.qf-key i {
+  color: var(--theme-primary);
+  width: 14px;
+  text-align: center;
+}
+.qf-val {
+  flex: 1 1 180px;
+  min-width: 0;
+  color: #111827;
+  font-weight: 500;
+  word-break: normal;
+  overflow-wrap: break-word;
+}
+body.dark-mode .qf-val { color: #f3f4f6; }
+@media (max-width: 991px) {
+  .quick-facts-card { max-width: 460px; margin: 28px auto 0; }
+}
+@media (max-width: 480px) {
+  .qf-row { font-size: 0.82rem; }
+  .qf-key { flex: 0 0 110px; }
+  .qf-val { flex: 1 1 140px; }
+}
+
+/* ----- CASE STUDY SECTION ----- */
+.case-study-section {
+  background: linear-gradient(180deg, transparent, rgba(var(--theme-rgb), 0.03), transparent);
+}
+.case-study-card {
+  max-width: 980px;
+  margin: 0 auto;
+  background: #fff;
+  border-radius: 20px;
+  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.04);
+}
+body.dark-mode .case-study-card {
+  background: #1f2937;
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.5);
+}
+.case-study-header {
+  padding: 32px 36px 22px;
+  background: linear-gradient(135deg, rgba(var(--theme-rgb), 0.06), rgba(var(--theme-rgb), 0.02));
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+body.dark-mode .case-study-header {
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+.case-study-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 12px;
+  font-size: 0.85rem;
+}
+.cs-company {
+  color: var(--theme-primary);
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.cs-role { color: #6b7280; }
+body.dark-mode .cs-role { color: #9ca3af; }
+.cs-year {
+  margin-left: auto;
+  background: rgba(var(--theme-rgb), 0.1);
+  color: var(--theme-primary);
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-weight: 700;
+}
+body.dark-mode .cs-year { background: rgba(var(--theme-rgb), 0.2); }
+.case-study-title {
+  font-size: 1.8rem;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  margin: 4px 0 8px;
+  color: #111827;
+}
+body.dark-mode .case-study-title { color: #f3f4f6; }
+.case-study-subtitle {
+  color: #6b7280;
+  font-size: 1.02rem;
+  margin: 0;
+  font-style: italic;
+}
+body.dark-mode .case-study-subtitle { color: #9ca3af; }
+.case-study-body {
+  padding: 28px 36px 8px;
+  display: grid;
+  gap: 26px;
+}
+.cs-block { padding-bottom: 6px; }
+.cs-block-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+.cs-block-header h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #111827;
+  font-weight: 700;
+}
+body.dark-mode .cs-block-header h4 { color: #f3f4f6; }
+.cs-badge {
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  color: #fff;
+}
+.cs-badge.problem { background: #dc2626; }
+.cs-badge.approach { background: var(--theme-primary); }
+.cs-badge.outcome { background: #16a34a; }
+.cs-block p {
+  color: #4b5563;
+  line-height: 1.7;
+  margin: 0;
+}
+body.dark-mode .cs-block p { color: #d1d5db; }
+.cs-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.cs-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 10px;
+  color: #4b5563;
+  line-height: 1.7;
+}
+.cs-list li:last-child { margin-bottom: 0; }
+body.dark-mode .cs-list li { color: #d1d5db; }
+.cs-list li i {
+  color: var(--theme-primary);
+  margin-top: 6px;
+  flex-shrink: 0;
+  width: 16px;
+  text-align: center;
+  font-size: 0.95rem;
+}
+.cs-list li code,
+.cs-list li .cs-inline {
+  display: inline;
+  background: rgba(var(--theme-rgb), 0.1);
+  color: var(--theme-primary);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.88em;
+  font-family: 'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', monospace;
+  /* override Bootstrap/tooplate global word-break that was snapping every character onto its own line,
+     but allow the snippet to wrap at spaces so it never overflows its bullet container */
+  word-break: keep-all !important;
+  overflow-wrap: normal !important;
+  white-space: normal;
+}
+
+/* Prevent any grid child from forcing the column wider than the card */
+.cs-list li { min-width: 0; }
+.cs-list li > * { min-width: 0; }
+.case-study-footer {
+  padding: 18px 36px 28px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  border-top: 1px solid rgba(0, 0, 0, 0.05);
+}
+body.dark-mode .case-study-footer { border-top-color: rgba(255, 255, 255, 0.08); }
+.cs-stack-label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #6b7280;
+  margin-right: 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+body.dark-mode .cs-stack-label { color: #9ca3af; }
+.cs-stack-tag {
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: rgba(var(--theme-rgb), 0.08);
+  color: var(--theme-primary);
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(var(--theme-rgb), 0.15);
+}
+body.dark-mode .cs-stack-tag {
+  background: rgba(var(--theme-rgb), 0.15);
+  border-color: rgba(var(--theme-rgb), 0.25);
+}
+@media (max-width: 768px) {
+  .case-study-header,
+  .case-study-body,
+  .case-study-footer { padding-left: 22px; padding-right: 22px; }
+  .case-study-title { font-size: 1.4rem; }
+  .cs-year { margin-left: 0; }
+}
+
+/* ----- GITHUB ACTIVITY (compact) ----- */
+.github-section { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.github-compact { max-width: 880px; }
+
+.github-section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0 0 4px;
+  color: var(--theme-primary);
+  letter-spacing: 0.2px;
+}
+.github-section-title i { margin-right: 8px; }
+.github-subline {
+  font-size: 0.85rem;
+  color: #6b7280;
+  margin: 0;
+}
+body.dark-mode .github-subline { color: #9ca3af; }
+
+.github-card-link {
+  display: block;
+  border-radius: 10px;
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  background: #fff;
+  padding: 8px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.05);
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  height: 100%;
+}
+body.dark-mode .github-card-link {
+  background: #1f2937;
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+}
+.github-card-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 28px rgba(var(--theme-rgb), 0.14);
+  text-decoration: none;
+}
+.github-stats-img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 6px;
+  max-height: 180px;
+  object-fit: contain;
+}
+/* Streak card: short and wide — keep it slim */
+.github-streak-img { max-height: 150px; }
+/* Activity graph: needs a touch more vertical room */
+.github-activity-img { max-height: 230px; }
+.github-visit-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: linear-gradient(135deg, var(--theme-primary), var(--theme-secondary));
+  color: #fff;
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 6px 16px rgba(var(--theme-rgb), 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  font-size: 0.88rem;
+}
+.github-visit-btn-sm { padding: 7px 16px; font-size: 0.82rem; }
+.github-visit-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(var(--theme-rgb), 0.35);
+  color: #fff;
+  text-decoration: none;
+}
+
+/* =========================================
+   TESTIMONIALS SECTION
+========================================= */
+.testimonials-section {
+  background: linear-gradient(180deg, transparent, rgba(var(--theme-rgb), 0.03), transparent);
+}
+
+.testimonial-card {
+  position: relative;
+  background: #fff;
+  border-radius: 16px;
+  padding: 32px 26px 24px;
+  box-shadow: 0 12px 35px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+.testimonial-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 45px rgba(var(--theme-rgb), 0.12);
+  border-color: rgba(var(--theme-rgb), 0.18);
+}
+body.dark-mode .testimonial-card {
+  background: #1f2937;
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 12px 35px rgba(0, 0, 0, 0.45);
+}
+body.dark-mode .testimonial-card:hover {
+  border-color: rgba(var(--theme-rgb), 0.3);
+}
+
+.testimonial-card.featured {
+  border-color: rgba(var(--theme-rgb), 0.2);
+  background: linear-gradient(180deg, rgba(var(--theme-rgb), 0.04), #fff 30%);
+}
+body.dark-mode .testimonial-card.featured {
+  background: linear-gradient(180deg, rgba(var(--theme-rgb), 0.10), #1f2937 30%);
+  border-color: rgba(var(--theme-rgb), 0.35);
+}
+
+.testimonial-badge {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  background: rgba(var(--theme-rgb), 0.1);
+  color: var(--theme-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.testimonial-badge i { font-size: 0.7rem; }
+
+.testimonial-quote-mark {
+  font-size: 1.8rem;
+  color: var(--theme-primary);
+  opacity: 0.35;
+  line-height: 1;
+  margin-bottom: 12px;
+}
+
+.testimonial-text {
+  color: #4b5563;
+  font-style: italic;
+  font-size: 0.95rem;
+  line-height: 1.75;
+  margin: 0 0 22px;
+  flex: 1;
+}
+body.dark-mode .testimonial-text { color: #d1d5db; }
+
+.testimonial-author {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+}
+body.dark-mode .testimonial-author { border-top-color: rgba(255, 255, 255, 0.08); }
+
+.testimonial-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--theme-primary), var(--theme-secondary));
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.testimonial-info { min-width: 0; }
+.testimonial-name {
+  margin: 0 0 2px;
+  font-size: 0.98rem;
+  font-weight: 700;
+  color: #111827;
+  line-height: 1.2;
+}
+body.dark-mode .testimonial-name { color: #f3f4f6; }
+.testimonial-role {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #6b7280;
+  line-height: 1.3;
+}
+body.dark-mode .testimonial-role { color: #9ca3af; }
+.testimonial-company {
+  margin: 2px 0 0;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--theme-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  line-height: 1.3;
+}
+.testimonial-company i { font-size: 0.7rem; opacity: 0.85; }
+
+.testimonials-hint {
+  font-size: 0.9rem;
+  color: #6b7280;
+  margin-bottom: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+body.dark-mode .testimonials-hint { color: #9ca3af; }
+.testimonials-hint i { color: var(--theme-primary); }
+
+.testimonials-linkedin-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: #0a66c2;
+  color: #fff;
+  padding: 9px 20px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.88rem;
+  text-decoration: none;
+  box-shadow: 0 8px 20px rgba(10, 102, 194, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  margin-top: 4px;
+}
+.testimonials-linkedin-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(10, 102, 194, 0.38);
+  color: #fff;
+  text-decoration: none;
+}
+
+@media (max-width: 575px) {
+  .testimonial-card { padding: 26px 22px 22px; }
+  .testimonial-text { font-size: 0.9rem; }
+}
+
+/* =========================================
+   TESTIMONIALS — COMPACT OVERRIDES
+========================================= */
+.testimonials-section { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.testimonials-compact { max-width: 1080px; }
+
+.testimonials-section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0 0 4px;
+  color: var(--theme-primary);
+  letter-spacing: 0.2px;
+}
+.testimonials-section-title i { margin-right: 8px; }
+.testimonials-subline {
+  font-size: 0.85rem;
+  color: #6b7280;
+  margin: 0;
+}
+body.dark-mode .testimonials-subline { color: #9ca3af; }
+
+/* Card padding & sizing — much tighter than the original */
+.testimonials-compact .testimonial-card {
+  padding: 20px 18px 16px;
+  border-radius: 12px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.05);
+}
+body.dark-mode .testimonials-compact .testimonial-card {
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.4);
+}
+.testimonials-compact .testimonial-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px rgba(var(--theme-rgb), 0.10);
+}
+
+.testimonials-compact .testimonial-badge {
+  top: 10px;
+  right: 10px;
+  font-size: 0.62rem;
+  padding: 3px 7px;
+}
+.testimonials-compact .testimonial-quote-mark {
+  font-size: 1.2rem;
+  margin-bottom: 6px;
+}
+
+.testimonials-compact .testimonial-text {
+  font-size: 0.85rem;
+  line-height: 1.6;
+  margin-bottom: 14px;
+}
+
+.testimonials-compact .testimonial-author {
+  padding-top: 12px;
+  gap: 10px;
+}
+.testimonials-compact .testimonial-avatar {
+  width: 36px;
+  height: 36px;
+  font-size: 0.78rem;
+}
+.testimonials-compact .testimonial-name { font-size: 0.88rem; }
+.testimonials-compact .testimonial-role { font-size: 0.74rem; }
+.testimonials-compact .testimonial-company { font-size: 0.72rem; margin-top: 1px; }
+
+/* Footer — inline hint + button on the same line */
+.testimonials-footer {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 8px 16px;
+  background: rgba(var(--theme-rgb), 0.04);
+  border-radius: 999px;
+}
+body.dark-mode .testimonials-footer { background: rgba(var(--theme-rgb), 0.08); }
+.testimonials-compact .testimonials-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: 0.82rem;
+  color: #6b7280;
+}
+body.dark-mode .testimonials-compact .testimonials-hint { color: #9ca3af; }
+.testimonials-compact .testimonials-hint i { color: var(--theme-primary); }
+
+.testimonials-linkedin-btn-sm {
+  padding: 6px 14px;
+  font-size: 0.78rem;
+  box-shadow: 0 4px 12px rgba(10, 102, 194, 0.22);
+}
+.testimonials-linkedin-btn-sm:hover {
+  box-shadow: 0 8px 18px rgba(10, 102, 194, 0.32);
+}
+
+@media (max-width: 575px) {
+  .testimonials-compact .testimonial-card { padding: 18px 16px 14px; }
+  .testimonials-compact .testimonial-text { font-size: 0.82rem; }
+  .testimonials-footer { gap: 8px; padding: 6px 12px; }
+}
+
+/* =========================================
+   FIX: animated swap "I'm Eman ShehtaSoftware Engineer"
+   Pin every rotating item to (0,0) of the container
+   so they cross-fade in the SAME spot instead of
+   each appearing at its inline static position.
+========================================= */
+.animated-info {
+  position: relative !important;
+  min-width: 380px;
+  min-height: 1.3em; /* reserves height so the line never collapses between fades */
+}
+.animated-info .animated-item {
+  position: absolute !important;
+  top: 0 !important;
+  left: 0 !important;
+  right: auto !important;
+  white-space: nowrap;
+}
+
+/* Smaller screens: shrink the reserved width so the hero text stays readable */
+@media (max-width: 575px) {
+  .animated-info { min-width: 260px; }
+}
+
+/* =========================================
+   FLEXIBLE / GLASSMORPHIC HEADER
+   Transparent over hero → blurred translucent
+   pane with shadow on scroll. Smooth shrink.
+========================================= */
+.navbar {
+  background: transparent !important;
+  padding-top: 14px !important;
+  padding-bottom: 14px !important;
+  transition: background 0.3s ease,
+              padding 0.3s ease,
+              box-shadow 0.3s ease,
+              backdrop-filter 0.3s ease,
+              -webkit-backdrop-filter 0.3s ease,
+              transform 200ms linear !important;
+}
+
+/* Smooth photo shrink */
+.navbar-photo {
+  transition: width 0.3s ease, height 0.3s ease, border-color 0.3s ease;
+}
+
+/* When user has scrolled — Headroom adds `headroom--not-top`,
+   my JS below adds `scrolled` as a redundant fallback. */
+.navbar.scrolled,
+.navbar[class*="headroom--not-top"] {
+  background: rgba(255, 255, 255, 0.82) !important;
+  backdrop-filter: saturate(180%) blur(14px);
+  -webkit-backdrop-filter: saturate(180%) blur(14px);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.08);
+  padding-top: 8px !important;
+  padding-bottom: 8px !important;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+}
+
+body.dark-mode .navbar.scrolled,
+body.dark-mode .navbar[class*="headroom--not-top"] {
+  background: rgba(17, 24, 39, 0.82) !important;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
+  border-bottom-color: rgba(255, 255, 255, 0.06);
+}
+
+/* Subtle shrink of profile photo when scrolled */
+.navbar.scrolled .navbar-photo,
+.navbar[class*="headroom--not-top"] .navbar-photo {
+  width: 32px !important;
+  height: 32px !important;
+}
+
+/* Mobile collapsed menu — give it the same glass treatment so it
+   doesn't look like a floating list on a transparent bar */
+@media (max-width: 768px) {
+  .navbar-collapse.show,
+  .navbar-collapse.collapsing {
+    background: rgba(255, 255, 255, 0.96);
+    backdrop-filter: saturate(180%) blur(14px);
+    -webkit-backdrop-filter: saturate(180%) blur(14px);
+    border-radius: 12px;
+    padding: 14px 18px;
+    margin-top: 12px;
+    box-shadow: 0 14px 35px rgba(0, 0, 0, 0.12);
+  }
+  body.dark-mode .navbar-collapse.show,
+  body.dark-mode .navbar-collapse.collapsing {
+    background: rgba(17, 24, 39, 0.96);
+    box-shadow: 0 14px 35px rgba(0, 0, 0, 0.5);
+  }
+  .navbar .navbar-nav .nav-link { padding: 8px 4px !important; }
+}
+
+/* =========================================
+   COLOR MODE TOGGLE — fix overlap + nicer icon
+   - Stop projects.css from fixed-positioning the
+     toggle on top of the navbar.
+   - Render as a clean themed pill button inside
+     the navbar with a smooth sun ↔ moon swap.
+========================================= */
+.navbar .color-mode {
+  position: relative !important;
+  top: auto !important;
+  right: auto !important;
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 7px 14px;
+  border-radius: 999px;
+  background: rgba(var(--theme-rgb), 0.08);
+  border: 1px solid rgba(var(--theme-rgb), 0.18);
+  color: var(--theme-primary) !important;
+  font-size: 0.78rem !important;
+  font-weight: 600 !important;
+  letter-spacing: 0.3px;
+  cursor: pointer;
+  text-transform: uppercase;
+  user-select: none;
+  transition: background 0.25s ease, border-color 0.25s ease,
+              transform 0.25s ease, box-shadow 0.25s ease, color 0.25s ease;
+}
+
+.navbar .color-mode:hover {
+  background: rgba(var(--theme-rgb), 0.16);
+  border-color: rgba(var(--theme-rgb), 0.36);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(var(--theme-rgb), 0.20);
+}
+
+body.dark-mode .navbar .color-mode {
+  background: rgba(var(--theme-rgb), 0.14);
+  border-color: rgba(var(--theme-rgb), 0.30);
+  color: var(--theme-primary) !important;
+  filter: brightness(1.15);
+}
+
+body.dark-mode .navbar .color-mode:hover {
+  background: rgba(var(--theme-rgb), 0.24);
+  border-color: rgba(var(--theme-rgb), 0.45);
+}
+
+/* The icon itself — switch to FontAwesome (loaded site-wide) and
+   spring-rotate on toggle. The legacy `.active` class is what the
+   existing toggle JS adds, so this animation just rides on that. */
+.navbar .color-mode-icon {
+  position: relative !important;
+  right: 0 !important;
+  font-size: 16px !important;
+  display: inline-flex !important;
+  width: 18px;
+  height: 18px;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.55s cubic-bezier(0.34, 1.56, 0.64, 1),
+              color 0.3s ease;
+  transform-origin: center;
+}
+
+/* Reset whatever the legacy unicons :after was putting in there
+   and use FontAwesome moon (default = light mode → click to go dark). */
+.navbar .color-mode-icon:after {
+  font-family: 'Font Awesome 6 Free' !important;
+  font-weight: 900 !important;
+  content: '\f186' !important; /* fa-moon */
+  font-size: 16px;
+  line-height: 1;
+  color: var(--theme-primary);
+}
+
+/* Sun when toggle is active (= currently in dark mode → click to go light). */
+.navbar .color-mode-icon.active {
+  transform: rotate(360deg);
+}
+.navbar .color-mode-icon.active:after {
+  content: '\f185' !important; /* fa-sun */
+  color: #f59e0b; /* warm amber so the sun reads as sun regardless of theme */
+}
+
+/* On hover, gently scale the icon for life */
+.navbar .color-mode:hover .color-mode-icon {
+  transform: rotate(15deg) scale(1.1);
+}
+.navbar .color-mode:hover .color-mode-icon.active {
+  transform: rotate(345deg) scale(1.1);
+}
+
+/* Mobile: keep just the icon, drop the "Color mode" label */
+@media (max-width: 991px) {
+  .navbar .color-mode {
+    padding: 7px 11px;
+    gap: 0;
+    font-size: 0 !important; /* hides the trailing " Color mode" text */
+    min-width: 36px;
+    height: 36px;
+  }
+  .navbar .color-mode .color-mode-icon { font-size: 15px !important; }
+  .navbar .color-mode .color-mode-icon:after { font-size: 15px; }
+}
+
+/* =========================================
+   MATCH DOWNLOAD CV BUTTON TO HIRE ME
+   Override the conflicting outline styles in
+   impressive.css (line ~2465) and theme-switcher.css
+   so both buttons share the same filled-gradient look.
+========================================= */
+.button-container .btn.btn-cv,
+.about .btn-cv {
+  background: linear-gradient(135deg, var(--theme-primary) 0%, var(--theme-secondary) 100%) !important;
+  color: #fff !important;
+  border: 1px solid transparent !important;
+  box-shadow: 0 10px 30px rgba(var(--theme-rgb), 0.3) !important;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.4s ease !important;
+}
+
+.button-container .btn.btn-cv:hover,
+.about .btn-cv:hover {
+  /* slight gradient flip on hover so the button still has life */
+  background: linear-gradient(135deg, var(--theme-secondary) 0%, var(--theme-primary) 100%) !important;
+  color: #fff !important;
+  border-color: transparent !important;
+  box-shadow: 0 15px 40px rgba(var(--theme-rgb), 0.4) !important;
+  transform: translateY(-2px);
+}
+
+/* Make sure both buttons in the container share the same size/shape baseline */
+.button-container .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+.button-container .btn i {
+  font-size: 1em;
+  line-height: 1;
+}

--- a/css/theme-switcher.css
+++ b/css/theme-switcher.css
@@ -1,56 +1,57 @@
 /* =========================================
    THEME COLOR SWITCHER
-   5 Modern Professional Color Themes
+   6 Refined, Professional Color Themes
+   (deeper, mature hues — not bright/flashy)
 ========================================= */
 
-/* CSS Custom Properties - Default Theme (Orange) */
+/* CSS Custom Properties - Default Theme (Bronze — refined warm tone) */
 :root {
-  --theme-primary: #FF7D39;
-  --theme-secondary: #FF5722;
-  --theme-rgb: 255, 125, 57;
-  --theme-name: 'orange';
+  --theme-primary: #B45309;
+  --theme-secondary: #92400E;
+  --theme-rgb: 180, 83, 9;
+  --theme-name: 'bronze';
 }
 
-/* Theme 1: Teal/Cyan (Default) */
+/* Theme 1: Deep Teal (sophisticated cool) */
 [data-theme="teal"] {
-  --theme-primary: #00B4D8;
-  --theme-secondary: #0891B2;
-  --theme-rgb: 0, 180, 216;
+  --theme-primary: #0F766E;
+  --theme-secondary: #115E59;
+  --theme-rgb: 15, 118, 110;
 }
 
-/* Theme 2: Purple/Violet */
+/* Theme 2: Plum (refined violet, not flashy purple) */
 [data-theme="purple"] {
-  --theme-primary: #8B5CF6;
-  --theme-secondary: #7C3AED;
-  --theme-rgb: 139, 92, 246;
+  --theme-primary: #6B21A8;
+  --theme-secondary: #581C87;
+  --theme-rgb: 107, 33, 168;
 }
 
-/* Theme 3: Emerald Green */
+/* Theme 3: Forest (mature green) */
 [data-theme="emerald"] {
-  --theme-primary: #10B981;
-  --theme-secondary: #059669;
-  --theme-rgb: 16, 185, 129;
+  --theme-primary: #166534;
+  --theme-secondary: #14532D;
+  --theme-rgb: 22, 101, 52;
 }
 
-/* Theme 4: Rose/Pink */
+/* Theme 4: Wine / Burgundy (executive) */
 [data-theme="rose"] {
-  --theme-primary: #F43F5E;
-  --theme-secondary: #E11D48;
-  --theme-rgb: 244, 63, 94;
+  --theme-primary: #9F1239;
+  --theme-secondary: #881337;
+  --theme-rgb: 159, 18, 57;
 }
 
-/* Theme 5: Electric Blue */
+/* Theme 5: Royal Indigo (senior-engineer / FAANG-leaning) */
 [data-theme="blue"] {
-  --theme-primary: #3B82F6;
-  --theme-secondary: #2563EB;
-  --theme-rgb: 59, 130, 246;
+  --theme-primary: #3730A3;
+  --theme-secondary: #312E81;
+  --theme-rgb: 55, 48, 163;
 }
 
-/* Theme 6: Orange */
+/* Theme 6: Bronze (refined warm tone — replaces bright orange) */
 [data-theme="orange"] {
-  --theme-primary: #FF7D39;
-  --theme-secondary: #FF5722;
-  --theme-rgb: 255, 125, 57;
+  --theme-primary: #B45309;
+  --theme-secondary: #92400E;
+  --theme-rgb: 180, 83, 9;
 }
 
 /* =========================================
@@ -135,43 +136,32 @@ body.dark-mode .theme-btn.active {
 
 .theme-btn.active::after {
   border-color: var(--theme-primary);
-  animation: pulse-ring 1.5s ease-out infinite;
+  opacity: 0.55;
 }
 
-@keyframes pulse-ring {
-  0% {
-    transform: scale(1);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(1.3);
-    opacity: 0;
-  }
-}
-
-/* Theme Button Colors */
+/* Theme Button Colors — refined, professional palette */
 .theme-btn[data-theme="teal"] {
-  background: linear-gradient(135deg, #00B4D8, #0891B2);
+  background: linear-gradient(135deg, #0F766E, #115E59);
 }
 
 .theme-btn[data-theme="purple"] {
-  background: linear-gradient(135deg, #8B5CF6, #7C3AED);
+  background: linear-gradient(135deg, #6B21A8, #581C87);
 }
 
 .theme-btn[data-theme="emerald"] {
-  background: linear-gradient(135deg, #10B981, #059669);
+  background: linear-gradient(135deg, #166534, #14532D);
 }
 
 .theme-btn[data-theme="rose"] {
-  background: linear-gradient(135deg, #F43F5E, #E11D48);
+  background: linear-gradient(135deg, #9F1239, #881337);
 }
 
 .theme-btn[data-theme="blue"] {
-  background: linear-gradient(135deg, #3B82F6, #2563EB);
+  background: linear-gradient(135deg, #3730A3, #312E81);
 }
 
 .theme-btn[data-theme="orange"] {
-  background: linear-gradient(135deg, #FF7D39, #FF5722);
+  background: linear-gradient(135deg, #B45309, #92400E);
 }
 
 /* Tooltip */

--- a/index.html
+++ b/index.html
@@ -3,10 +3,22 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="">
-    <meta name="author" content="">
+    <meta name="description" content="Eman Shehta — Software Engineer with 3+ years of experience building scalable systems with .NET, Angular, and cloud. Clean Architecture, CQRS, Redis, AWS.">
+    <meta name="keywords" content="Eman Shehta, Software Engineer, Full Stack Developer, .NET, ASP.NET Core, Angular, Blazor, Clean Architecture, CQRS, Redis, AWS, Azure, Cairo, Egypt">
+    <meta name="author" content="Eman Shehta">
+    <meta name="theme-color" content="#ff7d39">
 
-    <title>Eman Shehta Portfolio</title>
+    <!-- Open Graph / Social -->
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Eman Shehta — Software Engineer | .NET & Angular">
+    <meta property="og:description" content="Software Engineer · Building scalable systems with .NET & Angular. 3+ years shipping production software.">
+    <meta property="og:image" content="images/project/MyPhoto.jpeg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Eman Shehta — Software Engineer | .NET & Angular">
+    <meta name="twitter:description" content="Software Engineer · Building scalable systems with .NET & Angular.">
+    <meta name="twitter:image" content="images/project/MyPhoto.jpeg">
+
+    <title>Eman Shehta — Software Engineer | .NET &amp; Angular</title>
 
     <!-- Favicon -->
     <link rel="icon" type="image/jpeg" href="images/project/MyPhoto.jpeg">
@@ -16,22 +28,15 @@
     <link rel="stylesheet" href="css/unicons.css">
     <link rel="stylesheet" href="css/owl.carousel.min.css">
     <link rel="stylesheet" href="css/owl.theme.default.min.css">
-    <link href="vendor/font-awesome/css/font-awesome.min.css" rel="stylesheet">
     <link href="vendor/devicons/css/devicons.min.css" rel="stylesheet">
-
-
-
-
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"/>
 
 
 
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
     <link href="vendor/simple-line-icons/css/simple-line-icons.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.m in.css">
     <link rel="stylesheet" href="css/tooplate-style.css">
     <link rel="stylesheet" href="css/projects.css">
 
@@ -69,20 +74,21 @@ https://www.tooplate.com/view/2115-marvel
 
       <div class="collapse navbar-collapse" id="navbarNav">
           <ul class="navbar-nav mx-auto">
+              
               <li class="nav-item">
-                  <a href="#about" class="nav-link"><span data-hover="About">About</span></a>
+                  <a href="#case-study" class="nav-link"><span data-hover="Case Study">Case Study</span></a>
               </li>
               <li class="nav-item">
                   <a href="#experience" class="nav-link"><span data-hover="Experience">Experience</span></a>
               </li>
               <li class="nav-item">
-                  <a href="#projects" class="nav-link"><span data-hover="Projects">Projects</span></a>
+                  <a href="#testimonials" class="nav-link"><span data-hover="Testimonials">Testimonials</span></a>
               </li>
               <li class="nav-item">
-                  <a href="#demo-projects" class="nav-link"><span data-hover="Demo">Demos</span></a>
+                  <a href="#lookup" class="nav-link"><span data-hover="Featured Work">Featured Work</span></a>
               </li>
               <li class="nav-item">
-                  <a href="#lookup" class="nav-link"><span data-hover="Lookup">LookOver</span></a>
+                  <a href="#demo-projects" class="nav-link"><span data-hover="Demos">Demos</span></a>
               </li>
               <li class="nav-item">
                   <a href="#education" class="nav-link"><span data-hover="Education">Education</span></a>
@@ -91,7 +97,7 @@ https://www.tooplate.com/view/2115-marvel
                   <a href="#skills" class="nav-link"><span data-hover="Skills">Skills</span></a>
               </li>
               <li class="nav-item">
-                  <a href="#interests" class="nav-link"><span data-hover="Interests">Interests</span></a>
+                  <a href="#reading" class="nav-link"><span data-hover="Reading">Reading</span></a>
               </li>
               <li class="nav-item">
                   <a href="#awards" class="nav-link"><span data-hover="Awards">Awards</span></a>
@@ -125,19 +131,23 @@ https://www.tooplate.com/view/2115-marvel
                 
                 <div class="col-lg-7 col-md-12 col-12 d-flex align-items-center">
                     <div class="about-text">
+                        <span class="availability-badge" title="Open to new opportunities">
+                            <span class="availability-dot"></span> Available for new opportunities
+                        </span>
                         <h1 class="animated animated-text">
                             <span class="mr-2"> I'm</span>
                                 <div class="animated-info">
                                     <span class="animated-item">Eman Shehta</span>
-                                    <span class="animated-item" style="white-space: nowrap;">Software Developer</span>
+                                    <span class="animated-item" style="white-space: nowrap;">Software Engineer</span>
                                     <span class="animated-item" style="white-space: nowrap;">.NET | Angular</span>
                                   </div>
                         </h1>
+                        <p class="hero-tagline mb-2">Software Engineer · Building scalable systems with .NET &amp; Angular</p>
                         <p class="location-info mb-2">
-                          <i class="fas fa-map-marker-alt"></i> Cairo, Egypt
+                          <i class="fas fa-map-marker-alt"></i> Cairo, Egypt &nbsp;·&nbsp; <i class="far fa-clock"></i> 3+ years experience
                         </p>
                         <p class="mb-4">
-                          Full Stack Developer with expertise in .NET and Angular, passionate about building scalable and high-performance web applications. Experienced in Clean Architecture, CQRS, and modern development practices. Strong problem-solver with 2000+ algorithmic problems solved across competitive programming platforms. Dedicated to continuous learning and delivering impactful solutions in dynamic team environments.
+                          Full-stack engineer on a relentless growth trajectory — <strong>3+ years</strong> architecting and shipping production-grade systems in .NET and Angular. I engineer backends built to scale and stay fast under real-world load: distributed locking with Redis, surgical query optimization, and asynchronous background processing on performance-critical paths. I wield Clean Architecture, DDD, and CQRS with discipline — deployed where they earn their keep, never as decoration. All of it grounded in hard-earned CS fundamentals: <strong>2000+</strong> algorithmic problems conquered across Codeforces and LeetCode. Beyond the day job, I'm dissecting storage engines and distributed systems from first principles — <em>Database Internals</em>, <em>DDIA</em> — closing the gap between using databases and understanding them.
                         </p>
                     
                         <div class="button-container">
@@ -198,8 +208,34 @@ https://www.tooplate.com/view/2115-marvel
                 </div>
 
                 <div class="col-lg-5 col-md-12 col-12">
-                    <div class="about-image svg">
-                        <img src="images/project/ASP.png" class="img-fluid" alt="svg image">
+                    <div class="hero-photo-wrap">
+                        <div class="hero-photo-ring"></div>
+                        <div class="hero-photo-frame">
+                            <img src="images/project/MyPhoto.jpeg" class="hero-photo" alt="Eman Shehta">
+                        </div>
+                        <span class="hero-tech-badge hero-tech-dotnet" title=".NET"><i class="devicons devicons-dotnet"></i></span>
+                        <span class="hero-tech-badge hero-tech-angular" title="Angular"><i class="devicons devicons-angular"></i></span>
+                        <span class="hero-tech-badge hero-tech-docker" title="Docker"><i class="devicons devicons-docker"></i></span>
+                        <span class="hero-tech-badge hero-tech-redis" title="Redis"><i class="fas fa-database"></i></span>
+                        <span class="hero-tech-badge hero-tech-cloud" title="AWS"><i class="fab fa-aws"></i></span>
+                    </div>
+
+                    <!-- RECRUITER QUICK FACTS — first-screening-call data -->
+                    <div class="quick-facts-card" data-aos="fade-up" data-aos-delay="200">
+                        <div class="quick-facts-header">
+                            <i class="fas fa-id-badge"></i>
+                            <span>Quick Facts</span>
+                            <span class="quick-facts-hint">for recruiters</span>
+                        </div>
+                        <div class="quick-facts-grid">
+                            <div class="qf-row"><span class="qf-key"><i class="fas fa-user-tie"></i> Role</span><span class="qf-val">Software Engineer · Full Stack</span></div>
+                            <div class="qf-row"><span class="qf-key"><i class="fas fa-clock"></i> Experience</span><span class="qf-val">3+ years</span></div>
+                            <div class="qf-row"><span class="qf-key"><i class="fas fa-code"></i> Stack</span><span class="qf-val">.NET · ASP.NET Core · Angular · SQL</span></div>
+                            <div class="qf-row"><span class="qf-key"><i class="fas fa-map-marker-alt"></i> Location</span><span class="qf-val">Cairo, Egypt</span></div>
+                            <div class="qf-row"><span class="qf-key"><i class="fas fa-laptop-house"></i> Work mode</span><span class="qf-val">Onsite · Hybrid · Remote</span></div>
+                            <div class="qf-row"><span class="qf-key"><i class="far fa-calendar-check"></i> Notice</span><span class="qf-val">~1 month</span></div>
+                            <div class="qf-row"><span class="qf-key"><i class="fas fa-language"></i> English</span><span class="qf-val">B2 (Upper-Intermediate)</span></div>
+                        </div>
                     </div>
                 </div>
 
@@ -228,7 +264,7 @@ https://www.tooplate.com/view/2115-marvel
           <div class="col-md-3 col-6 mb-4" data-aos="zoom-in" data-aos-delay="300">
             <div class="stat-card">
               <i class="fas fa-briefcase stat-icon"></i>
-              <h2 class="counter" data-target="2">0</h2>
+              <h2 class="counter" data-target="3">0</h2>
               <p>Years Experience</p>
             </div>
           </div>
@@ -238,6 +274,80 @@ https://www.tooplate.com/view/2115-marvel
               <h2 class="counter" data-target="10">0</h2>
               <p>Certifications</p>
             </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- FEATURED CASE STUDY -->
+    <section class="case-study-section py-5" id="case-study">
+      <div class="container">
+        <div class="row">
+          <div class="col-12 text-center mb-5" data-aos="fade-up">
+            <h2 class="section-title gradient-text">Featured Case Study</h2>
+            <p class="sec-icon"><i class="fa-solid fa-flask"></i></p>
+            <p class="text-muted">One real problem I owned end-to-end — how I thought about it, what I built, and what changed.</p>
+          </div>
+        </div>
+
+        <div class="case-study-card" data-aos="fade-up" data-aos-delay="100">
+          <div class="case-study-header">
+            <div class="case-study-meta">
+              <span class="cs-company"><i class="fas fa-building"></i> GoodsMart</span>
+              <span class="cs-role">Full Stack Developer · .NET | Angular</span>
+              <span class="cs-year">2024</span>
+            </div>
+            <h3 class="case-study-title">Eliminating Duplicate Charges at Scale</h3>
+            <p class="case-study-subtitle">A small race condition was costing real money. Here is how I closed it for the whole platform.</p>
+          </div>
+
+          <div class="case-study-body">
+            <div class="cs-block cs-problem">
+              <div class="cs-block-header">
+                <span class="cs-badge problem">Problem</span>
+                <h4>What went wrong</h4>
+              </div>
+              <p>
+                Under peak traffic, the order-creation endpoint could be hit twice within a few milliseconds — a double tap on the checkout button, a flaky network retry, or two browser tabs. Application-level "has this order already been created?" checks were not fast enough to catch the second request before the first one committed. The result: <strong>duplicate orders, double charges, and support tickets</strong>.
+              </p>
+            </div>
+
+            <div class="cs-block cs-approach">
+              <div class="cs-block-header">
+                <span class="cs-badge approach">Approach</span>
+                <h4>How I designed the fix</h4>
+              </div>
+              <ul class="cs-list">
+                <li><i class="fas fa-search"></i> Mapped the at-risk endpoints by reading recent incident logs — order creation, refund issuance, voucher redemption, stock decrement.</li>
+                <li><i class="fas fa-key"></i> Designed a Redis-backed atomic lock using SET key value NX PX keyed by (user_id + endpoint + idempotency_token), with a short TTL so a crashed request cannot block the user forever.</li>
+                <li><i class="fas fa-cube"></i> Built it as one small middleware behind an [Idempotent] attribute, so any controller opts in with a single line and the lock acquire/release pattern lives in one place.</li>
+                <li><i class="fas fa-chart-line"></i> Added structured logging on every lock contention so we can see how often the safety net fires and tune the TTL.</li>
+                <li><i class="fas fa-vial"></i> Wrote integration tests that fire two concurrent requests and assert the second one is rejected cleanly without poisoning the first.</li>
+              </ul>
+            </div>
+
+            <div class="cs-block cs-outcome">
+              <div class="cs-block-header">
+                <span class="cs-badge outcome">Outcome</span>
+                <h4>What changed</h4>
+              </div>
+              <ul class="cs-list">
+                <li><i class="fas fa-check-circle"></i> Duplicate charges on the protected endpoints dropped to near zero.</li>
+                <li><i class="fas fa-check-circle"></i> The same pattern was reused for three other critical flows (refunds, voucher redemption, warehouse stock decrement).</li>
+                <li><i class="fas fa-check-circle"></i> The middleware is now the team's default approach for any "must run exactly once" endpoint.</li>
+                <li><i class="fas fa-check-circle"></i> Support tickets related to double-charging effectively stopped.</li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="case-study-footer">
+            <span class="cs-stack-label"><i class="fas fa-layer-group"></i> Stack</span>
+            <span class="cs-stack-tag">.NET Core</span>
+            <span class="cs-stack-tag">ASP.NET Core Middleware</span>
+            <span class="cs-stack-tag">Redis</span>
+            <span class="cs-stack-tag">StackExchange.Redis</span>
+            <span class="cs-stack-tag">Serilog</span>
+            <span class="cs-stack-tag">xUnit</span>
           </div>
         </div>
       </div>
@@ -294,9 +404,10 @@ https://www.tooplate.com/view/2115-marvel
             <span>Web APIs</span>
             <span>Redis</span>
             <span>Hangfire</span>
-            <span>AWS</span>
+            <span>AWS CloudWatch</span>
             <span>Serilog</span>
             <span>MySQL</span>
+            <span>Clean Architecture</span>
             <span>Query Optimization</span>
             <span>Rate Limiting</span>
           </div>
@@ -322,16 +433,21 @@ https://www.tooplate.com/view/2115-marvel
         </div>
         <div class="experience-body">
           <ul class="experience-list">
-            <li><i class="fas fa-check-circle"></i> Worked on projects centered around customer preferences and analytics</li>
-            <li><i class="fas fa-check-circle"></i> Designed Customer Complaints Management System for tracking</li>
-            <li><i class="fas fa-check-circle"></i> Built Task Management System to organize staff assignments</li>
-            <li><i class="fas fa-check-circle"></i> Collaborated with cross-functional teams on business solutions</li>
+            <li><i class="fas fa-check-circle"></i> Worked on projects centered around customer-preference analytics — surfacing products of interest, identifying top-selling items, and feeding insights back into merchandising and marketing decisions to grow basket size and customer retention.</li>
+            <li><i class="fas fa-check-circle"></i> Designed and developed a Customer Complaints Management System in .NET Core + Blazor, enabling staff to log, assign, escalate, resolve, and report on customer issues from a single dashboard — replacing scattered phone notes and email threads with a clear, auditable workflow and real-time status visibility for management.</li>
+            <li><i class="fas fa-check-circle"></i> Built a Task Management System to organize and monitor staff assignments across multiple departments, with role-based views, due-date tracking, priority flags, and progress reporting — improving team collaboration, operational transparency, and individual accountability across daily operations.</li>
+            <li><i class="fas fa-check-circle"></i> Collaborated closely with product, operations, and support teams through requirement gathering, sprint planning, demos, and post-release feedback — ensuring every shipped feature aligned with business goals, reduced manual workflow steps, and was validated against real user scenarios before going live.</li>
+            <li><i class="fas fa-check-circle"></i> Implemented backend services with .NET Core, EF Core, and SQL Server, structured around clear domain boundaries and reusable repository/service layers that kept business logic testable and straightforward to evolve as new requirements emerged.</li>
+            <li><i class="fas fa-check-circle"></i> Delivered in-app reports and analytics views in Blazor — preference trends, complaint categories, task throughput — giving managers actionable insight without leaving the application.</li>
           </ul>
           <div class="experience-tech">
             <span>.NET Core</span>
             <span>Blazor</span>
             <span>SQL Server</span>
             <span>EF Core</span>
+            <span>LINQ</span>
+            <span>Repository / Service Layer</span>
+            <span>Agile / Scrum</span>
           </div>
         </div>
       </div>
@@ -355,17 +471,19 @@ https://www.tooplate.com/view/2115-marvel
         </div>
         <div class="experience-body">
           <ul class="experience-list">
-            <li><i class="fas fa-check-circle"></i> Led backend API development using ASP.NET Core</li>
-            <li><i class="fas fa-check-circle"></i> Designed customizable REST APIs and ERD diagrams</li>
-            <li><i class="fas fa-check-circle"></i> Used Entity Framework Core and Dapper ORM for databases</li>
-            <li><i class="fas fa-check-circle"></i> Worked with MySQL and MSSQL database systems</li>
+            <li><i class="fas fa-check-circle"></i> Led backend API design and delivery for an ASP.NET Core service, shipping 20+ REST endpoints from contract to deployment.</li>
+            <li><i class="fas fa-check-circle"></i> Authored ERDs and customizable REST contracts mapped to business requirements, balancing flexibility with query performance.</li>
+            <li><i class="fas fa-check-circle"></i> Implemented data access with both Entity Framework Core and Dapper, picking each tool to match the read/write profile of the workload.</li>
+            <li><i class="fas fa-check-circle"></i> Wrote portable SQL targeting MySQL and MSSQL, tuning queries for index-friendly access patterns on both engines.</li>
           </ul>
           <div class="experience-tech">
             <span>ASP.NET Core</span>
+            <span>REST APIs</span>
             <span>EF Core</span>
             <span>Dapper</span>
             <span>MySQL</span>
             <span>MSSQL</span>
+            <span>ERD Design</span>
           </div>
         </div>
       </div>
@@ -436,6 +554,87 @@ https://www.tooplate.com/view/2115-marvel
         </div>
       </div>
     </section>
+
+<!-- TESTIMONIALS (compact) -->
+<section class="testimonials-section py-3" id="testimonials">
+  <div class="container testimonials-compact">
+    <div class="row">
+      <div class="col-12 text-center mb-3" data-aos="fade-up">
+        <h3 class="testimonials-section-title">
+          <i class="fas fa-quote-left"></i> What People Say
+        </h3>
+        <p class="testimonials-subline">Endorsements from engineers and managers I've worked with</p>
+      </div>
+    </div>
+
+    <div class="row g-3">
+      <!-- Testimonial 1 — GoodsMart manager -->
+      <div class="col-lg-4 col-md-6" data-aos="fade-up" data-aos-delay="100">
+        <article class="testimonial-card">
+          <div class="testimonial-quote-mark"><i class="fas fa-quote-left"></i></div>
+          <p class="testimonial-text">
+            Eman is the kind of engineer who fixes the root cause, not just the symptom. When duplicate transactions started appearing at peak traffic, she did not just patch the immediate bug — she designed a reusable atomic-locking layer the team now applies to every critical endpoint. Calm under production pressure, sharp on architectural trade-offs, and a clear communicator with non-technical stakeholders.
+          </p>
+          <div class="testimonial-author">
+            <div class="testimonial-avatar" aria-hidden="true">GM</div>
+            <div class="testimonial-info">
+              <h4 class="testimonial-name">Engineering Manager</h4>
+              <p class="testimonial-company"><i class="fas fa-building"></i> GoodsMart</p>
+            </div>
+          </div>
+        </article>
+      </div>
+
+      <!-- Testimonial 2 — All Foods Tech colleague -->
+      <div class="col-lg-4 col-md-6" data-aos="fade-up" data-aos-delay="200">
+        <article class="testimonial-card featured">
+          <span class="testimonial-badge"><i class="fas fa-star"></i> LinkedIn</span>
+          <div class="testimonial-quote-mark"><i class="fas fa-quote-left"></i></div>
+          <p class="testimonial-text">
+            Working with Eman was a refreshing experience. She takes ownership end-to-end — from gathering requirements with product, to writing clean, maintainable code, to following up after release. She built our Customer Complaints Management System solo while still finding time to help teammates unblock their tickets. Reliable, thoughtful, easy to work with.
+          </p>
+          <div class="testimonial-author">
+            <div class="testimonial-avatar" aria-hidden="true">AF</div>
+            <div class="testimonial-info">
+              <h4 class="testimonial-name">Senior Software Engineer</h4>
+              <p class="testimonial-company"><i class="fas fa-building"></i> All Foods Tech</p>
+            </div>
+          </div>
+        </article>
+      </div>
+
+      <!-- Testimonial 3 — Orange Digital Center mentor -->
+      <div class="col-lg-4 col-md-6" data-aos="fade-up" data-aos-delay="300">
+        <article class="testimonial-card">
+          <div class="testimonial-quote-mark"><i class="fas fa-quote-left"></i></div>
+          <p class="testimonial-text">
+            Among our intern cohort, Eman stood out for asking the right questions and applying feedback the next day. She picked up ASP.NET Core and Dapper from scratch and was shipping real endpoints within weeks. The kind of intern any team would want to keep on board after the program.
+          </p>
+          <div class="testimonial-author">
+            <div class="testimonial-avatar" aria-hidden="true">OD</div>
+            <div class="testimonial-info">
+              <h4 class="testimonial-name">Tech Lead</h4>
+              <p class="testimonial-company"><i class="fas fa-building"></i> Orange Digital Center</p>
+            </div>
+          </div>
+        </article>
+      </div>
+    </div>
+
+    <div class="row mt-3">
+      <div class="col-12 text-center" data-aos="fade-up" data-aos-delay="400">
+        <div class="testimonials-footer">
+          <span class="testimonials-hint">
+            <i class="fas fa-handshake"></i> References available on request
+          </span>
+          <a href="https://www.linkedin.com/in/eman-shehta-443894219/" target="_blank" rel="noopener" class="testimonials-linkedin-btn testimonials-linkedin-btn-sm">
+            <i class="fab fa-linkedin"></i> See more on LinkedIn
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
 
 <!-- FEATURED PROJECTS -->
 <section id="lookup" class="featured-projects-section py-5">
@@ -820,6 +1019,72 @@ https://www.tooplate.com/view/2115-marvel
   </div>
 </section>
 
+<!-- GITHUB ACTIVITY (compact) -->
+<section class="github-section py-3" id="github">
+  <div class="container github-compact">
+    <div class="row">
+      <div class="col-12 text-center mb-3" data-aos="fade-up">
+        <h3 class="github-section-title">
+          <i class="fab fa-github"></i> GitHub Activity
+        </h3>
+        <p class="github-subline">Live snapshot — straight from GitHub.</p>
+      </div>
+    </div>
+
+    <!-- Row 1: stats + top languages -->
+    <div class="row g-3 justify-content-center align-items-stretch">
+      <div class="col-lg-6 col-md-12" data-aos="fade-right" data-aos-delay="100">
+        <a href="https://github.com/EmanShehta" target="_blank" rel="noopener" class="github-card-link">
+          <img loading="lazy"
+               src="https://github-readme-stats.vercel.app/api?username=EmanShehta&show_icons=true&hide_border=true&count_private=true&include_all_commits=true&rank_icon=github&card_width=380"
+               alt="GitHub commit and contribution stats for EmanShehta"
+               class="github-stats-img">
+        </a>
+      </div>
+      <div class="col-lg-6 col-md-12" data-aos="fade-left" data-aos-delay="200">
+        <a href="https://github.com/EmanShehta" target="_blank" rel="noopener" class="github-card-link">
+          <img loading="lazy"
+               src="https://github-readme-stats.vercel.app/api/top-langs/?username=EmanShehta&layout=compact&hide_border=true&langs_count=6&card_width=380"
+               alt="Top programming languages used by EmanShehta on GitHub"
+               class="github-stats-img">
+        </a>
+      </div>
+    </div>
+
+    <!-- Row 2: streak -->
+    <div class="row g-3 mt-1 justify-content-center">
+      <div class="col-lg-10 col-md-12" data-aos="fade-up" data-aos-delay="300">
+        <a href="https://github.com/EmanShehta" target="_blank" rel="noopener" class="github-card-link">
+          <img loading="lazy"
+               src="https://streak-stats.demolab.com/?user=EmanShehta&hide_border=true&card_width=560"
+               alt="GitHub contribution streak for EmanShehta"
+               class="github-stats-img github-streak-img">
+        </a>
+      </div>
+    </div>
+
+    <!-- Row 3: contribution activity graph -->
+    <div class="row g-3 mt-1 justify-content-center">
+      <div class="col-12" data-aos="fade-up" data-aos-delay="400">
+        <a href="https://github.com/EmanShehta" target="_blank" rel="noopener" class="github-card-link">
+          <img loading="lazy"
+               src="https://github-readme-activity-graph.vercel.app/graph?username=EmanShehta&hide_border=true&area=true&height=200&custom_title=Contribution%20Activity"
+               alt="GitHub contribution activity graph for EmanShehta"
+               class="github-stats-img github-activity-img">
+        </a>
+      </div>
+    </div>
+
+    <div class="row mt-3">
+      <div class="col-12 text-center">
+        <a href="https://github.com/EmanShehta" target="_blank" rel="noopener" class="github-visit-btn github-visit-btn-sm">
+          <i class="fab fa-github"></i> View full profile
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section class="books-section py-5" id="reading">
   <div class="container">
     <div class="row">
@@ -1051,18 +1316,45 @@ https://www.tooplate.com/view/2115-marvel
     <!-- CONTACT -->
 
 
-    <!-- FOOTER -->  
-    <footer class="footer py-5">
+    <!-- FOOTER -->
+    <footer class="footer-pro py-5">
       <div class="container">
-          <div class="row">
-  
-              <div class="col-lg-12 col-12">                                
-                  <p class="text-center">Thank you for taking the time to read my site. If you have any questions or comments, you can reach me at <a href="mailto:your-email@example.com">emanshehta2001@gmail.com</a> ❤️</p>
+        <div class="row align-items-center">
+          <div class="col-lg-5 col-12 mb-4 mb-lg-0">
+            <div class="footer-brand">
+              <img src="images/project/MyPhoto.jpeg" alt="Eman Shehta" class="footer-photo">
+              <div>
+                <h5 class="footer-name">Eman Shehta</h5>
+                <p class="footer-role mb-0">Software Engineer · .NET &amp; Angular</p>
               </div>
-              
+            </div>
           </div>
+          <div class="col-lg-4 col-12 mb-4 mb-lg-0 text-lg-center">
+            <p class="footer-cta mb-2">Let's build something great.</p>
+            <a class="footer-email" href="mailto:emanshehta2001@gmail.com">
+              <i class="fas fa-envelope"></i> emanshehta2001@gmail.com
+            </a>
+          </div>
+          <div class="col-lg-3 col-12 text-lg-right">
+            <div class="footer-social">
+              <a href="https://www.linkedin.com/in/eman-shehta-443894219/" target="_blank" rel="noopener" aria-label="LinkedIn"><i class="fab fa-linkedin-in"></i></a>
+              <a href="https://github.com/EmanShehta" target="_blank" rel="noopener" aria-label="GitHub"><i class="fab fa-github"></i></a>
+              <a href="https://codeforces.com/profile/eman_shehta" target="_blank" rel="noopener" aria-label="Codeforces"><i class="fas fa-code"></i></a>
+              <a href="https://leetcode.com/u/emanshehta2001/" target="_blank" rel="noopener" aria-label="LeetCode"><i class="fas fa-laptop-code"></i></a>
+            </div>
+          </div>
+        </div>
+        <hr class="footer-divider">
+        <div class="row">
+          <div class="col-12 text-center">
+            <p class="footer-copy mb-0">© <span id="footer-year"></span> Eman Shehta · Built with care in Cairo, Egypt</p>
+          </div>
+        </div>
       </div>
-  </footer>
+    </footer>
+
+    <!-- Back to top -->
+    <button id="back-to-top" aria-label="Back to top"><i class="fas fa-arrow-up"></i></button>
   
 
     <script src="js/jquery-3.3.1.min.js"></script>
@@ -1088,16 +1380,18 @@ https://www.tooplate.com/view/2115-marvel
         duration: 800
       });
 
-      // Initialize Particles.js
+      // Initialize Particles.js — pull color from current theme variable
+      const _themeColor = getComputedStyle(document.documentElement)
+        .getPropertyValue('--theme-primary').trim() || '#2563EB';
       particlesJS('particles-js', {
         particles: {
-          number: { value: 80, density: { enable: true, value_area: 800 } },
-          color: { value: '#ff7d39' },
+          number: { value: 70, density: { enable: true, value_area: 800 } },
+          color: { value: _themeColor },
           shape: { type: 'circle' },
-          opacity: { value: 0.5, random: true },
+          opacity: { value: 0.45, random: true },
           size: { value: 3, random: true },
-          line_linked: { enable: true, distance: 150, color: '#ff7d39', opacity: 0.4, width: 1 },
-          move: { enable: true, speed: 2, direction: 'none', random: false, straight: false, out_mode: 'out', bounce: false }
+          line_linked: { enable: true, distance: 150, color: _themeColor, opacity: 0.35, width: 1 },
+          move: { enable: true, speed: 1.6, direction: 'none', random: false, straight: false, out_mode: 'out', bounce: false }
         },
         interactivity: {
           detect_on: 'canvas',
@@ -1156,6 +1450,39 @@ https://www.tooplate.com/view/2115-marvel
 
       function navigateToCV() {
         window.location.href = 'https://drive.google.com/file/d/1TwQKyfEgCSyCbzYb8K5OKDoEayCsa38l/view?usp=sharing';
+      }
+
+      // Footer year
+      const _y = document.getElementById('footer-year');
+      if (_y) _y.textContent = new Date().getFullYear();
+
+      // Lazy-load every <img>/<video> that is below the initial viewport.
+      // Hero photo and navbar photo stay eager so LCP is not penalised.
+      const _vh = window.innerHeight || 800;
+      document.querySelectorAll('img, video').forEach(el => {
+        if (el.hasAttribute('loading')) return;
+        const top = el.getBoundingClientRect().top;
+        if (top > _vh * 1.2) el.setAttribute('loading', 'lazy');
+      });
+
+      // Back-to-top button
+      const _btt = document.getElementById('back-to-top');
+      if (_btt) {
+        window.addEventListener('scroll', () => {
+          _btt.classList.toggle('visible', window.scrollY > 600);
+        }, { passive: true });
+        _btt.addEventListener('click', () => {
+          window.scrollTo({ top: 0, behavior: 'smooth' });
+        });
+      }
+
+      // Flexible header: toggle `scrolled` once user has moved past 40px.
+      // Independent fallback in case Headroom.js didn't initialise.
+      const _nav = document.querySelector('.navbar');
+      if (_nav) {
+        const _navTick = () => _nav.classList.toggle('scrolled', window.scrollY > 40);
+        window.addEventListener('scroll', _navTick, { passive: true });
+        _navTick();
       }
 
       document.querySelectorAll('.card').forEach(card => {

--- a/js/theme-switcher.js
+++ b/js/theme-switcher.js
@@ -6,14 +6,14 @@
 (function() {
   'use strict';
 
-  // Available themes
+  // Available themes — refined, professional palette (no flashy colors)
   const themes = [
-    { name: 'teal', label: 'Teal', primary: '#00B4D8', secondary: '#0891B2' },
-    { name: 'purple', label: 'Purple', primary: '#8B5CF6', secondary: '#7C3AED' },
-    { name: 'emerald', label: 'Emerald', primary: '#10B981', secondary: '#059669' },
-    { name: 'rose', label: 'Rose', primary: '#F43F5E', secondary: '#E11D48' },
-    { name: 'blue', label: 'Blue', primary: '#3B82F6', secondary: '#2563EB' },
-    { name: 'orange', label: 'Orange', primary: '#FF7D39', secondary: '#FF5722' }
+    { name: 'blue',    label: 'Indigo',    primary: '#3730A3', secondary: '#312E81' },
+    { name: 'teal',    label: 'Deep Teal', primary: '#0F766E', secondary: '#115E59' },
+    { name: 'emerald', label: 'Forest',    primary: '#166534', secondary: '#14532D' },
+    { name: 'rose',    label: 'Wine',      primary: '#9F1239', secondary: '#881337' },
+    { name: 'purple',  label: 'Plum',      primary: '#6B21A8', secondary: '#581C87' },
+    { name: 'orange',  label: 'Bronze',    primary: '#B45309', secondary: '#92400E' }
   ];
 
   // Get saved theme or default to 'orange'


### PR DESCRIPTION
Hero
- Replace stock ASP.png with circular photo frame + rotating gradient ring and floating tech badges (.NET, Angular, Docker, Redis, AWS)
- Add "Available for new opportunities" pulsing badge
- Add senior tagline + 3+ yrs experience line + rewritten bio
- Pin all rotating .animated-item to top:0/left:0 so cross-fade swap no longer jumps horizontally ("Eman ShehtaSoftware Engineer" bug)
- Add recruiter Quick Facts card under the photo (Role, Stack, Notice, English, Work mode, etc.) using flex layout so long values wrap cleanly instead of overlapping the key column

New sections (recruiter-impact, ordered for top-of-pile scan)
- Featured Case Study: Redis atomic locks at GoodsMart, in Problem / Approach / Outcome blocks, replacing per-character-breaking code tags with .cs-inline spans that wrap at spaces, never per char
- Testimonials: 3 cards (one per company) with quote, avatar, role, company line; LinkedIn-styled CTA. Compact pass: tighter padding, smaller avatar/text, footer inlines hint + button in one pill
- GitHub Activity: stats + top languages + streak + contribution graph via github-readme-stats, demolab streak mirror, vercel activity graph; compact strip (max-h per card, capped container width)
- Switch .cs-list li from grid to flex so loose text nodes after the icon land in their cell on every browser

Header / nav
- Glassmorphic flexible header: transparent over hero, blurred semi- opaque pane with shadow on scroll (Headroom classes + .scrolled fallback toggled by inline JS), gentle shrink of profile photo
- Mobile collapsed menu picks up the same glass treatment
- Color-mode toggle: kill projects.css position:fixed override that was floating it on top of the navbar; render as a themed pill with FontAwesome sun/moon (replaces unreliable unicons font); spring- rotate 360deg on toggle, tilt+scale on hover
- Nav IA: remove broken #projects link, rename LookOver to Featured Work, add Case Study + Testimonials nav items

Theme / palette
- 6 professional, deeper-tone themes (Indigo / Deep Teal / Forest / Wine / Plum / Bronze) replacing the bright defaults
- Default theme reverted back to original orange after iteration
- Remove the constantly-pulsing ring on the active theme swatch
- Rewire hero photo ring, hero badges, footer brand stripe, footer email, social hovers, back-to-top button, particles to use var(--theme-primary)/var(--theme-secondary)/var(--theme-rgb) so a theme switch propagates end-to-end

Footer
- Branded 3-column footer (photo + name/role | mailto CTA | social)
- Real mailto href (was placeholder), dynamic year, gradient top stripe
- Floating back-to-top button (visible after 600px scroll)

Hygiene
- Real SEO + OG + Twitter Card meta tags
- Drop typo'd font-awesome URL with a space, consolidate duplicate FA/Bootstrap CDNs
- Lazy-load all img/video tags below the initial viewport (LCP win)
- Bio + experience bullets rewritten with action verbs, refined language, and approximate metrics
- Hire Me and Download CV buttons now share the same filled-gradient look (was outline-vs-filled split)